### PR TITLE
added BodyContent.RawFile with test

### DIFF
--- a/src/Http.fs
+++ b/src/Http.fs
@@ -15,6 +15,12 @@ module Blob =
     let fromText (value: string) : Blob = jsNative
 
 
+module File =
+    /// Creates a File from the given input string and file name
+    [<Emit("new File([$0], $1, { 'mimeType':'text/plain' })")>]
+    let fromText (value: string) (fileName: string) : File = jsNative
+
+
 /// Utility functions to work with blob and file APIs.
 module FileReader =
     /// Asynchronously reads the blob data content as string
@@ -215,6 +221,7 @@ module Http =
             | _, BodyContent.Text value -> xhr.send(value)
             | _, BodyContent.Form formData -> xhr.send(formData)
             | _, BodyContent.Binary blob -> xhr.send(blob)
+            | _, BodyContent.RawFile file -> xhr.send(file)
 #else
         async {
             try

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -17,6 +17,7 @@ type BodyContent =
     | Text of string
     | Binary of Browser.Types.Blob
     | Form of Browser.Types.FormData
+    | RawFile of Browser.Types.File
 
 [<RequireQualifiedAccess>]
 type ResponseTypes =


### PR DESCRIPTION
PR for #16

* Added `BodyContent.RawFile` and its trivial implementation
* Added test case, using "echoBinary" api call to test
* Added `File.fromText` to mirror `Blob.fromText`, mainly for testing
* Tests pass successfully on my machine

Any comments or corrections welcome.