### PR TITLE
Removing prerelease flag

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,7 +7,7 @@ nuget Fable.Browser.Dom
 nuget Fable.Remoting.Json
 nuget Fable.SimpleJson
 nuget FSharp.Core
-nuget Fable.Core prerelease
+nuget Fable.Core
 nuget Suave
 nuget Selenium.WebDriver
 


### PR DESCRIPTION
@Zaid-Ajaj Thanks for this lib. 😄 
This pull request removes the NU1603 warning about Fable.Core being imported as 3.0.0-prerelease.