### PR TITLE
Fix behavior around receiving null or empty headers

### DIFF
--- a/src/Http.fs
+++ b/src/Http.fs
@@ -208,11 +208,7 @@ module Http =
                         | _ -> ResponseContent.Unknown xhr.response
 
                     responseHeaders =
-                        let headers = xhr.getAllResponseHeaders()
-
-                        printfn $"XHR Headers: %A{headers}"
-
-                        headers
+                        xhr.getAllResponseHeaders()
                         |> splitAt "\r\n"
                         |> Array.choose (fun headerLine ->
                             let parts = splitAt ":" headerLine

--- a/src/Http.fs
+++ b/src/Http.fs
@@ -135,7 +135,7 @@ module Http =
           content = ResponseContent.Text "" }
 
     let private splitAt (delimiter: string) (input: string) : string [] =
-        if String.IsNullOrEmpty input then [| input |]
+        if String.IsNullOrEmpty input then Array.empty
         else input.Split([| delimiter |], StringSplitOptions.None)
 
     let private serializeMethod = function
@@ -208,7 +208,11 @@ module Http =
                         | _ -> ResponseContent.Unknown xhr.response
 
                     responseHeaders =
-                        xhr.getAllResponseHeaders()
+                        let headers = xhr.getAllResponseHeaders()
+
+                        printfn $"XHR Headers: %A{headers}"
+
+                        headers
                         |> splitAt "\r\n"
                         |> Array.choose (fun headerLine ->
                             let parts = splitAt ":" headerLine


### PR DESCRIPTION
Under some runtimes (eg. Hermes from react-native), `xhr.getAllResponseHeaders()` can return `null`. While there was some code to handle that case (and the case of an empty string), it seems like it was incorrectly putting the `null` (or empty string) element inside the return array, instead of just returning an empty array. In the case of `null`, this would result in an exception when calling `key.ToLower()`.